### PR TITLE
Fix missing inline code marker index.md

### DIFF
--- a/files/en-us/web/api/canvas_api/tutorial/drawing_shapes/index.md
+++ b/files/en-us/web/api/canvas_api/tutorial/drawing_shapes/index.md
@@ -312,7 +312,7 @@ The next type of paths available are [Bézier curves](/en-US/docs/Glossary/Bezie
 - {{domxref("CanvasRenderingContext2D.quadraticCurveTo", "quadraticCurveTo(cp1x, cp1y, x, y)")}}
   - : Draws a quadratic Bézier curve from the current pen position to the end point specified by `x` and `y`, using the control point specified by `cp1x` and `cp1y`.
 - {{domxref("CanvasRenderingContext2D.bezierCurveTo", "bezierCurveTo(cp1x, cp1y, cp2x, cp2y, x, y)")}}
-  - : Draws a cubic Bézier curve from the current pen position to the end point specified by `x` and `y`, using the control points specified by (`cp1x`, `cp1y`) and (cp2x, cp2y).
+  - : Draws a cubic Bézier curve from the current pen position to the end point specified by `x` and `y`, using the control points specified by (`cp1x`, `cp1y`) and (`cp2x`, `cp2y`).
 
 The difference between these is that a quadratic Bézier curve has a start and an end point (blue dots) and just one **control point** (indicated by the red dot) while a cubic Bézier curve uses two control points.
 ![Quadratic and Bezier curve comparison.](canvas_curves.png)


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

In the `bezierCurveTo(cp1x, cp1y, cp2x, cp2y, x, y)` function explanation the `cp2x` and `cp2y` have missing backtick.

<!-- ✍️ Summarize your changes in one or two sentences -->

### Motivation

I am learning the Canvas API to implement a feature for a website and I found this very small issue.

<!-- ❓ Why are you making these changes and how do they help readers? -->

### Additional details

<!-- 🔗 Link to release notes, vendor docs, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->


<!-- 👷‍♀️ After submitting, go to the "Checks" tab of your PR for the build status -->
